### PR TITLE
Use `conda run` in Pinokio scripts for 5.x compatibility

### DIFF
--- a/install.json
+++ b/install.json
@@ -7,57 +7,23 @@
       }
     },
     {
-      "method": "shell.start",
+      "method": "shell.run",
       "params": {
-        "path": "infernosaber"
+        "message": "conda create -n inferno_env -y python=3.10"
       }
     },
     {
-      "method": "shell.enter",
+      "method": "shell.run",
       "params": {
-        "message": "conda create -n inferno_env -y python=3.10",
-        "on": [
-          {
-            "event": null,
-            "return": true
-          }
-        ]
+        "path": "infernosaber",
+        "message": "conda install -n inferno_env -c conda-forge -y ffmpeg=4.3.1 aubio pydub"
       }
     },
     {
-      "method": "shell.enter",
+      "method": "shell.run",
       "params": {
-        "message": "{{os.platform() === 'win32' ? 'conda activate inferno_env' : 'source activate inferno_env'}}",
-        "on": [
-          {
-            "event": null,
-            "return": true
-          }
-        ]
-      }
-    },
-    {
-      "method": "shell.enter",
-      "params": {
-        "message": "conda install -c conda-forge -y ffmpeg=4.3.1 aubio pydub",
-        "on": [
-          {
-            "event": null,
-            "return": true
-          }
-        ]
-      }
-    },
-    {
-      "method": "shell.enter",
-      "params": {
-        "message": "pip install --isolated -r requirements.txt",
-        "on": [
-          {
-            "event": null,
-            "return": true
-          }
-        ]
+        "path": "infernosaber",
+        "message": "conda run -n inferno_env pip install --isolated -r requirements.txt"
       }
     },
     {

--- a/start.json
+++ b/start.json
@@ -7,21 +7,9 @@
       }
     },
     {
-      "method": "shell.enter",
+      "method": "shell.run",
       "params": {
-        "message": "{{os.platform() === 'win32' ? 'conda activate inferno_env' : 'source activate inferno_env'}}",
-        "on": [
-          {
-            "event": null,
-            "return": true
-          }
-        ]
-      }
-    },
-    {
-      "method": "shell.enter",
-      "params": {
-        "message": "python main_app.py",
+        "message": "conda run -n inferno_env python main_app.py",
         "on": [
           {
             "event": "/(http://[0-9.:]+)/",


### PR DESCRIPTION
### Motivation
- The one-click install and launch scripts stopped working under Pinokio 5.x due to reliance on activating Conda environments via interactive shells.
- The previous flow assumed environment activation would persist between `shell.enter` steps, which is unreliable in the newer runtime.
- The change aims to make installs and starts work deterministically without requiring activation logic.

### Description
- Replaced `shell.enter` steps with `shell.run` and removed the `shell.start` step in `install.json` to simplify execution flow.
- Changed creation command to `conda create -n inferno_env -y python=3.10` and use `conda install -n inferno_env -c conda-forge -y ffmpeg=4.3.1 aubio pydub` to install packages into the named env.
- Switched `pip install` to `conda run -n inferno_env pip install --isolated -r requirements.txt` in `install.json` and updated `start.json` to `conda run -n inferno_env python main_app.py` to run the app without activating the env.
- Kept existing logic to write `install_successfull.txt` and capture the server URL from the app output as before.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c248a33b483279c6203d10ba8d204)