### PR TITLE
Update Pinokio app scripts for v5 compatibility (use non-interactive conda run and shell.run)

### DIFF
--- a/install.json
+++ b/install.json
@@ -7,63 +7,29 @@
       }
     },
     {
-      "method": "shell.start",
+      "method": "shell.run",
       "params": {
-        "path": "infernosaber"
-      }
-    },
-    {
-      "method": "shell.enter",
-      "params": {
-        "message": "conda create -n inferno_env -y python=3.10",
-        "on": [
-          {
-            "event": null,
-            "return": true
-          }
-        ]
-      }
-    },
-    {
-      "method": "shell.enter",
-      "params": {
-        "message": "{{os.platform() === 'win32' ? 'conda activate inferno_env' : 'source activate inferno_env'}}",
-        "on": [
-          {
-            "event": null,
-            "return": true
-          }
-        ]
-      }
-    },
-    {
-      "method": "shell.enter",
-      "params": {
-        "message": "conda install -c conda-forge -y ffmpeg=4.3.1 aubio pydub",
-        "on": [
-          {
-            "event": null,
-            "return": true
-          }
-        ]
-      }
-    },
-    {
-      "method": "shell.enter",
-      "params": {
-        "message": "pip install --isolated -r requirements.txt",
-        "on": [
-          {
-            "event": null,
-            "return": true
-          }
-        ]
+        "message": "conda create -y -n inferno_env python=3.10 || conda install -y -n inferno_env python=3.10"
       }
     },
     {
       "method": "shell.run",
       "params": {
-        "message": "echo. > install_successfull.txt"
+        "message": "conda install -y -n inferno_env -c conda-forge ffmpeg=4.3.1 aubio pydub"
+      }
+    },
+    {
+      "method": "shell.run",
+      "params": {
+        "message": "conda run -n inferno_env python -m pip install --isolated -r requirements.txt",
+        "path": "infernosaber"
+      }
+    },
+    {
+      "method": "fs.write",
+      "params": {
+        "path": "install_successfull.txt",
+        "text": ""
       }
     },
     {

--- a/start.json
+++ b/start.json
@@ -9,22 +9,10 @@
     {
       "method": "shell.enter",
       "params": {
-        "message": "{{os.platform() === 'win32' ? 'conda activate inferno_env' : 'source activate inferno_env'}}",
+        "message": "conda run -n inferno_env python main_app.py",
         "on": [
           {
-            "event": null,
-            "return": true
-          }
-        ]
-      }
-    },
-    {
-      "method": "shell.enter",
-      "params": {
-        "message": "python main_app.py",
-        "on": [
-          {
-            "event": "/(http://[0-9.:]+)/",
+            "event": "/(http:\\/\\/[0-9.:]+)/",
             "return": "{{event.matches[0][1]}}"
           }
         ]

--- a/update.json
+++ b/update.json
@@ -1,35 +1,31 @@
 {
-    "run": [
-      {
-        "method": "shell.start",
-        "params": {
-          "path": "infernosaber"
-        }
-      },
-      {
-        "method": "shell.enter",
-        "params": {
-          "message": "git fetch origin main_app && git reset --hard origin/main_app",
-          "on": [
-            {
-              "event": null,
-              "return": true
-            }
-          ]
-        }
-      },
-      {
-        "method": "input",
-        "params": {
-          "title": "Update Success",
-          "description": "The app has been updated successfully!"
-        }
-      },
-      {
-        "method": "browser.open",
-        "params": {
-          "uri": "/?selected=infernosaber"
-        }
+  "run": [
+    {
+      "method": "shell.run",
+      "params": {
+        "message": "git fetch origin main_app && git reset --hard origin/main_app",
+        "path": "infernosaber"
       }
-    ]
-  }
+    },
+    {
+      "method": "shell.run",
+      "params": {
+        "message": "conda run -n inferno_env python -m pip install --isolated -r requirements.txt",
+        "path": "infernosaber"
+      }
+    },
+    {
+      "method": "input",
+      "params": {
+        "title": "Update Success",
+        "description": "The app has been updated successfully!"
+      }
+    },
+    {
+      "method": "browser.open",
+      "params": {
+        "uri": "/?selected=infernosaber"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
### Motivation
- Pinokio 5.x changed how shell sessions and activation behave, breaking interactive `conda activate` flows used previously. 
- The install/start/update scripts must run non-interactively inside Pinokio's JSON-RPC shell APIs to work reliably under 5.x. 
- Ensure Python dependencies are installed into the app environment without relying on an interactive shell session. 
- Preserve URL capture and session handling while making the flows robust to Pinokio's v5 shell semantics. 

### Description
- Reworked `install.json` to replace `shell.start`/`shell.enter` interactive activation with `shell.run` commands and to run `conda create -y -n inferno_env` with a fallback, `conda install -y -n inferno_env`, then `conda install -y -n inferno_env -c conda-forge ffmpeg=4.3.1 aubio pydub`. 
- Changed the requirements installation to use `conda run -n inferno_env python -m pip install --isolated -r requirements.txt` with `path: infernosaber`, and replaced the `echo` file creation with `fs.write` to create `install_successfull.txt`. 
- Updated `start.json` to launch the server via `conda run -n inferno_env python main_app.py` (single non-interactive command) while keeping the HTTP URL capture regex and session storage. 
- Updated `update.json` to use `shell.run` scoped to `infernosaber` for `git fetch`/`reset` and to re-run `conda run -n inferno_env python -m pip install --isolated -r requirements.txt` after updating. 

### Testing
- No automated tests were executed for these script changes. 
- Changes were staged and committed successfully to the repository with the message `Update Pinokio scripts for 5.x shell usage`. 
- Manual or CI test runs were not requested in this change set. 
- Recommend running the install/start/update flows inside a Pinokio v5 environment as a follow-up smoke test.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d8c83883c83278d098333c5e9aca4)