### PR TITLE
Add Pinokio 1-click installer (pip + conda support)

### DIFF
--- a/install.js
+++ b/install.js
@@ -1,0 +1,47 @@
+module.exports = async () => {
+  const script = {
+    run: [
+      {
+        method: "shell.run",
+        params: {
+          message: [
+            "git clone -b main_app https://github.com/fred-brenner/InfernoSaber---BeatSaber-Automapper app"
+          ]
+        }
+      },
+      {
+        method: "shell.run",
+        params: {
+          venv: "env",
+          path: "app",
+          message: [
+            "python -m pip install --upgrade pip",
+            "pip install -r requirements.txt"
+          ]
+        }
+      },
+      {
+        method: "fs.link",
+        params: {
+          venv: "app/env"
+        }
+      },
+      {
+        method: "notify",
+        params: {
+          html: "Install complete. Click the Start tab to launch InfernoSaber."
+        }
+      }
+    ]
+  }
+
+  script.requires = [
+    {
+      type: "conda",
+      name: ["ffmpeg", "libsndfile", "libsamplerate", "aubio"],
+      args: "-c conda-forge"
+    }
+  ]
+
+  return script
+}

--- a/pinokio.js
+++ b/pinokio.js
@@ -1,0 +1,94 @@
+module.exports = {
+  version: "1.0",
+  title: "InfernoSaber",
+  description: "Flexible Beat Saber automapper with an easy Gradio-based UI.",
+  icon: "icon.png",
+  menu: async (kernel, info) => {
+    const installed = info.exists("app/env")
+    const running = {
+      install: info.running("install.js"),
+      start: info.running("start.js"),
+      update: info.running("update.js"),
+      reset: info.running("reset.js")
+    }
+
+    if (running.install) {
+      return [{
+        default: true,
+        icon: "fa-solid fa-plug",
+        text: "Installing",
+        href: "install.js"
+      }]
+    }
+
+    if (installed) {
+      if (running.start) {
+        const local = info.local("start.js")
+        if (local && local.url) {
+          return [{
+            default: true,
+            icon: "fa-solid fa-rocket",
+            text: "Open InfernoSaber",
+            href: local.url,
+            popout: true
+          }, {
+            icon: "fa-solid fa-terminal",
+            text: "Terminal",
+            href: "start.js"
+          }]
+        }
+        return [{
+          default: true,
+          icon: "fa-solid fa-terminal",
+          text: "Terminal",
+          href: "start.js"
+        }]
+      }
+
+      if (running.update) {
+        return [{
+          default: true,
+          icon: "fa-solid fa-rotate",
+          text: "Updating",
+          href: "update.js"
+        }]
+      }
+
+      if (running.reset) {
+        return [{
+          default: true,
+          icon: "fa-solid fa-rotate-left",
+          text: "Resetting",
+          href: "reset.js"
+        }]
+      }
+
+      return [{
+        default: true,
+        icon: "fa-solid fa-power-off",
+        text: "Start",
+        href: "start.js"
+      }, {
+        icon: "fa-solid fa-rotate",
+        text: "Update",
+        href: "update.js"
+      }, {
+        icon: "fa-solid fa-plug",
+        text: "Install",
+        href: "install.js"
+      }, {
+        icon: "fa-regular fa-circle-xmark",
+        text: "Reset",
+        href: "reset.js",
+        confirm: "Are you sure you want to remove the current app install?"
+      }]
+    }
+
+    return [{
+      default: true,
+      icon: "fa-solid fa-plug",
+      text: "Install",
+      href: "install.js"
+    }]
+  }
+}

--- a/reset.js
+++ b/reset.js
@@ -1,0 +1,10 @@
+module.exports = {
+  run: [
+    {
+      method: "fs.rm",
+      params: {
+        path: "app"
+      }
+    }
+  ]
+}

--- a/start.js
+++ b/start.js
@@ -1,0 +1,35 @@
+module.exports = {
+  daemon: true,
+  run: [
+    {
+      method: "shell.run",
+      params: {
+        venv: "env",
+        env: {
+          GRADIO_SERVER_NAME: "127.0.0.1"
+        },
+        path: "app",
+        message: [
+          "python main_app.py"
+        ],
+        on: [{
+          event: "/http:\/\/\\S+/",
+          done: true
+        }]
+      }
+    },
+    {
+      method: "local.set",
+      params: {
+        url: "{{input.event[0]}}"
+      }
+    },
+    {
+      method: "proxy.start",
+      params: {
+        uri: "{{local.url}}",
+        name: "InfernoSaber"
+      }
+    }
+  ]
+}

--- a/update.js
+++ b/update.js
@@ -1,0 +1,22 @@
+module.exports = {
+  run: [
+    {
+      method: "shell.run",
+      params: {
+        path: "app",
+        message: "git pull"
+      }
+    },
+    {
+      method: "shell.run",
+      params: {
+        venv: "env",
+        path: "app",
+        message: [
+          "python -m pip install --upgrade pip",
+          "pip install -r requirements.txt"
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
### Motivation
- Provide a Pinokio-compatible 1-click installer for InfernoSaber so the app can be installed and managed from Pinokio v5-style scripts.
- Support both `pip` and `conda` installations to cover audio/video native dependencies and Python packages across platforms.
- Enable a managed lifecycle (install, start, update, reset) and surface a convenient menu entry inside the Pinokio UI.
- Capture the Gradio/HTTP launch URL so Pinokio can open the running InfernoSaber web UI automatically.

### Description
- Add `pinokio.js` with app metadata and dynamic `menu` wiring that shows `Install`, `Start`, `Update`, and `Reset` actions based on `info.exists` and `info.running` state.
- Add `install.js` which clones the `main_app` branch, creates a virtualenv and runs `pip install -r requirements.txt`, links the venv with `fs.link`, and declares `script.requires` with `type: "conda"` for `ffmpeg`, `libsndfile`, `libsamplerate`, and `aubio`.
- Add `start.js` which runs `python main_app.py` in a daemon `shell.run`, watches the terminal for an `http://` URL, stores it via `local.set`, and exposes it with `proxy.start` so Pinokio can open the UI.
- Add `update.js` and `reset.js` to perform `git pull` + pip re-install and to remove the `app` folder respectively, completing the app lifecycle.

### Testing
- No automated tests were executed for these script-only changes.
- The files were added and committed locally (`git commit` succeeded) and a PR was created to include the new installer scripts.
- These scripts are intended to be executed by the Pinokio runtime, which will perform runtime validation (install/start/update/reset) when run in that environment.
- Manual runtime testing in a Pinokio instance is recommended to validate platform-specific `conda` vs `pip` behavior and the Gradio URL capture.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950fa5dfaa8832784cfb28789ae7096)