### PR TITLE
Add Pinokio v5 one‑click installer scripts for InfernoSaber

### DIFF
--- a/install.js
+++ b/install.js
@@ -1,0 +1,46 @@
+module.exports = {
+  run: [
+    {
+      method: "shell.run",
+      params: {
+        message: [
+          "git clone --branch main_app --depth 1 https://github.com/fred-brenner/InfernoSaber---BeatSaber-Automapper app",
+        ]
+      }
+    },
+    {
+      method: "shell.run",
+      params: {
+        path: "app",
+        message: [
+          "conda create -y -p conda python=3.10"
+        ]
+      }
+    },
+    {
+      method: "shell.run",
+      params: {
+        path: "app",
+        message: [
+          "conda install -y -p conda -c conda-forge ffmpeg aubio"
+        ]
+      }
+    },
+    {
+      method: "shell.run",
+      params: {
+        path: "app",
+        message: [
+          "conda run -p conda python -m pip install --upgrade pip",
+          "conda run -p conda python -m pip install -r requirements.txt"
+        ]
+      }
+    },
+    {
+      method: "notify",
+      params: {
+        html: "Install complete. Click 'Start' to launch InfernoSaber."
+      }
+    }
+  ]
+}

--- a/pinokio.js
+++ b/pinokio.js
@@ -1,0 +1,72 @@
+const path = require("path")
+
+module.exports = {
+  version: "1.5",
+  title: "InfernoSaber",
+  description: "Flexible Beat Saber automapper with a Gradio UI for inference and map generation.",
+  icon: "icon.png",
+  menu: async (kernel) => {
+    const installing = await kernel.running(__dirname, "install.js")
+    const running = await kernel.running(__dirname, "start.js")
+    const installed = await kernel.exists(__dirname, "app", "conda")
+
+    if (installing) {
+      return [{
+        default: true,
+        icon: "fa-solid fa-plug",
+        text: "Installing",
+        href: "install.js",
+      }]
+    }
+
+    if (installed) {
+      if (running) {
+        const local = kernel.memory.local[path.resolve(__dirname, "start.js")]
+        if (local && local.url) {
+          return [{
+            icon: "fa-solid fa-rocket",
+            text: "Open InfernoSaber",
+            href: local.url,
+            popout: true,
+          }, {
+            icon: "fa-solid fa-terminal",
+            text: "Terminal",
+            href: "start.js",
+          }]
+        }
+
+        return [{
+          icon: "fa-solid fa-terminal",
+          text: "Terminal",
+          href: "start.js",
+        }]
+      }
+
+      return [{
+        default: true,
+        icon: "fa-solid fa-power-off",
+        text: "Start",
+        href: "start.js",
+      }, {
+        icon: "fa-solid fa-rotate",
+        text: "Update",
+        href: "update.js",
+      }, {
+        icon: "fa-solid fa-plug",
+        text: "Reinstall",
+        href: "install.js",
+      }, {
+        icon: "fa-regular fa-circle-xmark",
+        text: "Reset",
+        href: "reset.js",
+      }]
+    }
+
+    return [{
+      default: true,
+      icon: "fa-solid fa-plug",
+      text: "Install",
+      href: "install.js",
+    }]
+  }
+}

--- a/reset.js
+++ b/reset.js
@@ -1,0 +1,10 @@
+module.exports = {
+  run: [
+    {
+      method: "fs.rm",
+      params: {
+        path: "app"
+      }
+    }
+  ]
+}

--- a/start.js
+++ b/start.js
@@ -1,0 +1,35 @@
+module.exports = {
+  daemon: true,
+  run: [
+    {
+      id: "launch",
+      method: "shell.run",
+      params: {
+        path: "app",
+        env: {
+          PYTHONUNBUFFERED: "1"
+        },
+        message: [
+          "conda run -p conda python main_app.py"
+        ],
+        on: [{
+          event: "/http:\/\/\S+/",
+          done: true
+        }]
+      }
+    },
+    {
+      method: "local.set",
+      params: {
+        url: "{{input.event[0]}}"
+      }
+    },
+    {
+      method: "proxy.start",
+      params: {
+        uri: "{{local.url}}",
+        name: "InfernoSaber"
+      }
+    }
+  ]
+}

--- a/update.js
+++ b/update.js
@@ -1,0 +1,31 @@
+module.exports = {
+  run: [
+    {
+      method: "shell.run",
+      params: {
+        path: "app",
+        message: [
+          "git fetch --all",
+          "git checkout main_app",
+          "git pull"
+        ]
+      }
+    },
+    {
+      method: "shell.run",
+      params: {
+        path: "app",
+        message: [
+          "conda install -y -p conda -c conda-forge ffmpeg aubio",
+          "conda run -p conda python -m pip install -r requirements.txt"
+        ]
+      }
+    },
+    {
+      method: "notify",
+      params: {
+        html: "Update complete. Restart InfernoSaber if it is running."
+      }
+    }
+  ]
+}


### PR DESCRIPTION
### Motivation
- Provide a Pinokio 1‑click installer for InfernoSaber so users can install and run the `main_app` branch through Pinokio.
- Support both Conda and pip workflows to handle audio/FFmpeg/Aubio dependencies that often require Conda packages.
- Ensure the app UI launched by Gradio is discoverable by Pinokio by detecting the app URL and proxying it.
- Include update and reset helpers so installations can be updated or removed from the Pinokio UI.

### Description
- Add `pinokio.js` which defines the app metadata/menu for Pinokio and exposes `Install`, `Start`, `Update`, `Reinstall`, and `Reset` actions.
- Add `install.js` that clones the `main_app` branch, creates a Conda environment at `conda`, installs `ffmpeg` and `aubio` via Conda, and then runs `conda run -p conda python -m pip install -r requirements.txt` to install Python dependencies.
- Add `start.js` as a daemon that launches the app with `conda run -p conda python main_app.py`, waits for the Gradio HTTP URL event, stores it with `local.set`, and starts a Pinokio proxy with `proxy.start`.
- Add `update.js` to pull the latest `main_app` code and reapply Conda/pip dependency installs, and `reset.js` to remove the downloaded `app` folder.

### Testing
- No automated tests were executed for these installer/script additions.
- The patch only adds Pinokio installer scripts and metadata; runtime behavior should be validated in a Pinokio environment with Conda available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950fa5dfaa8832784cfb28789ae7096)